### PR TITLE
Set form action to absolute value

### DIFF
--- a/src/Form/SearchForm.php
+++ b/src/Form/SearchForm.php
@@ -34,7 +34,7 @@ class SearchForm extends FormBase {
     ];
 
     $form['#attributes'] = ['class' => ['SearchForm']];
-    $form['#action'] = 'search';
+    $form['#action'] = '/search';
     $form['#method'] = 'get';
 
     return $form;


### PR DESCRIPTION
Fixes the form action to always submit to `/search` rather than `/current/path/search`.